### PR TITLE
qualify Allocator as emb::Allocator

### DIFF
--- a/emb/fsm.cpp
+++ b/emb/fsm.cpp
@@ -205,7 +205,7 @@ void Signal::broadcast() {
   }
 }
 
-void buildExecutor(Allocator &allocator, FsmFramework::Scheduler &scheduler,
+void buildExecutor(emb::Allocator &allocator, FsmFramework::Scheduler &scheduler,
                    FsmFramework::Fsm &fsm) {
   auto *executor = allocator.allocate<FsmFramework::Scheduler::Executor>(
       FsmFramework::Scheduler::Entry(&fsm));

--- a/emb/fsm.hpp
+++ b/emb/fsm.hpp
@@ -118,7 +118,7 @@ template <class T> void Fsm::nextState(void (T::*next)()) {
   this->next = (State)next;
 }
 
-void buildExecutor(Allocator &allocator, FsmFramework::Scheduler &scheduler,
+void buildExecutor(emb::Allocator &allocator, FsmFramework::Scheduler &scheduler,
                    FsmFramework::Fsm &fsm);
 }
 


### PR DESCRIPTION
fixes compillation issue with `fsm.hpp` and `fsm.cpp`