### PR TITLE
Feature/or.check next state

### DIFF
--- a/emb/fsm.hpp
+++ b/emb/fsm.hpp
@@ -30,6 +30,13 @@ public:
   */
   template <class T> void nextState(void (T::*next)());
 
+  /*!
+  \brief Checks the next state of the state machine
+  \param next The state to check, whether it is next. This can be a class
+  function pointer of any class which can be cast into the \ref Fsm class.
+  */
+  template <class T> bool isNextState(void (T::*next)());
+
 protected:
   void start(Fsm &newParent);
 
@@ -118,6 +125,10 @@ protected:
 
 template <class T> void Fsm::nextState(void (T::*next)()) {
   this->next = (State)next;
+}
+
+template <class T> bool Fsm::isNextState(void (T::*next)()) {
+  return this->next == (State)next;
 }
 
 void buildExecutor(emb::Allocator &allocator,

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -7,8 +7,6 @@
 using emb::array;
 using namespace FsmFramework;
 
-bool TestFsm::expired() { return Fsm::expired(); }
-
 void TestFsm::initial() {}
 
 void TestFsm::increment() { counter++; }

--- a/test/test_fsm.cpp
+++ b/test/test_fsm.cpp
@@ -257,3 +257,13 @@ TEST(Fsm, WaitsForMultipleSignals) {
     LONGS_EQUAL(executionCount + 1, fsm.counter);
   }
 }
+
+TEST(Fsm, CheckNextState) {
+  testFsm.nextState(&TestFsm::ping);
+
+  scheduler.execute();
+  CHECK(testFsm.isNextState(&TestFsm::pong));
+
+  scheduler.execute();
+  CHECK(testFsm.isNextState(&TestFsm::ping));
+}

--- a/test/test_fsm.hpp
+++ b/test/test_fsm.hpp
@@ -37,8 +37,7 @@ struct FsmTestGroupBase : public Utest {
 };
 
 struct TestFsm : public Fsm {
-
-  bool expired();
+  using Fsm::expired;
 
   virtual void initial() override;
   void increment();


### PR DESCRIPTION
Add ability to confirm what the next state is assigned to be. (Also simplified use of `expired()` in the unit tests.)